### PR TITLE
feat: add secured webhook to trigger Netlify rebuilds

### DIFF
--- a/docs/content-rebuild-webhook.md
+++ b/docs/content-rebuild-webhook.md
@@ -1,0 +1,65 @@
+# Rebuild jovylle.com when content CDN updates
+
+When `content.jovylle.com` publishes new JSON, call this webhook so Netlify rebuilds jovylle.com and refreshes prerendered `/personal-projects`.
+
+## 1. Netlify env vars (jovylle.com site)
+
+In **Site configuration → Environment variables** (Production):
+
+| Variable | Description |
+|----------|-------------|
+| `NETLIFY_BUILD_HOOK_URL` | From **Build & deploy → Build hooks → Add build hook**. Paste the full hook URL (e.g. `https://api.netlify.com/build_hooks/...`). |
+| `REBUILD_WEBHOOK_SECRET` | Long random string you generate. Shared with the content repo only. |
+
+Redeploy once after setting these so the function sees the vars.
+
+## 2. Webhook URL
+
+```http
+POST https://jovylle.com/.netlify/functions/trigger-rebuild
+X-Rebuild-Secret: <REBUILD_WEBHOOK_SECRET>
+```
+
+Or:
+
+```http
+Authorization: Bearer <REBUILD_WEBHOOK_SECRET>
+```
+
+Success: `202` with `{ "ok": true, "message": "Netlify rebuild triggered" }`.
+
+## 3. Manual test
+
+```bash
+curl -sf -X POST \
+  -H "X-Rebuild-Secret: YOUR_SECRET" \
+  https://jovylle.com/.netlify/functions/trigger-rebuild
+```
+
+## 4. GitHub Actions (content / CMS repo)
+
+After your workflow deploys `/data` to `content.jovylle.com`, add:
+
+```yaml
+- name: Rebuild jovylle.com (personal projects prerender)
+  if: success()
+  env:
+    JOVYLLE_REBUILD_SECRET: ${{ secrets.JOVYLLE_REBUILD_SECRET }}
+  run: |
+    curl -sf -X POST \
+      -H "X-Rebuild-Secret: ${JOVYLLE_REBUILD_SECRET}" \
+      https://jovylle.com/.netlify/functions/trigger-rebuild
+```
+
+In the **content repo** GitHub settings → Secrets:
+
+- `JOVYLLE_REBUILD_SECRET` — same value as `REBUILD_WEBHOOK_SECRET` on Netlify.
+
+## 5. Direct build hook (alternative)
+
+You can POST to `NETLIFY_BUILD_HOOK_URL` from the content repo without this function. The function keeps the build hook URL off the content repo and adds a shared secret.
+
+## Notes
+
+- `/personal-projects` is prerendered at build time; a rebuild is required for CDN JSON changes to appear there.
+- `/highlights` still fetches in the browser (separate URL); it does not need a rebuild unless you change site code.

--- a/example.env
+++ b/example.env
@@ -1,1 +1,5 @@
 OPENAI_API_KEY=asd
+
+# Netlify only — rebuild webhook (see docs/content-rebuild-webhook.md)
+# NETLIFY_BUILD_HOOK_URL=https://api.netlify.com/build_hooks/xxxxxxxx
+# REBUILD_WEBHOOK_SECRET=generate-a-long-random-string

--- a/netlify/functions/trigger-rebuild.js
+++ b/netlify/functions/trigger-rebuild.js
@@ -1,0 +1,76 @@
+const json = (statusCode, body, extraHeaders = {}) => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json',
+    ...extraHeaders
+  },
+  body: JSON.stringify(body)
+})
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Rebuild-Secret',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+}
+
+/** POST with X-Rebuild-Secret or Authorization: Bearer <secret> to start a Netlify build. */
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: corsHeaders, body: '' }
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'Method Not Allowed' }, corsHeaders)
+  }
+
+  const secret = process.env.REBUILD_WEBHOOK_SECRET
+  const buildHookUrl = process.env.NETLIFY_BUILD_HOOK_URL
+
+  if (!secret || !buildHookUrl) {
+    return json(
+      503,
+      { error: 'Rebuild webhook not configured on this site' },
+      corsHeaders
+    )
+  }
+
+  const provided =
+    event.headers?.['x-rebuild-secret'] ||
+    event.headers?.['X-Rebuild-Secret'] ||
+    (event.headers?.authorization || event.headers?.Authorization || '')
+      .replace(/^Bearer\s+/i, '')
+      .trim()
+
+  if (!provided || provided !== secret) {
+    return json(401, { error: 'Unauthorized' }, corsHeaders)
+  }
+
+  try {
+    const res = await fetch(buildHookUrl, { method: 'POST' })
+    const detail = await res.text().catch(() => '')
+
+    if (!res.ok) {
+      return json(
+        502,
+        {
+          error: 'Netlify build hook failed',
+          status: res.status,
+          detail: detail.slice(0, 300)
+        },
+        corsHeaders
+      )
+    }
+
+    return json(
+      202,
+      { ok: true, message: 'Netlify rebuild triggered' },
+      corsHeaders
+    )
+  } catch (err) {
+    return json(
+      500,
+      { error: 'Failed to trigger rebuild', message: err?.message || 'Unknown error' },
+      corsHeaders
+    )
+  }
+}


### PR DESCRIPTION
Expose trigger-rebuild function for the content CDN pipeline to refresh prerendered personal-projects after JSON publishes, with setup docs.